### PR TITLE
File sharing 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Notes2Text"
         tools:targetApi="31">
+        <provider
+            android:name="com.example.notes2text.file_sharing.use_case.MyFileProvider"
+            android:authorities="com.example.notes2text.file_sharing.use_case.MyFileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
         <activity
             android:name=".adapters.ActivitySwitchController"
             android:exported="false" />

--- a/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
@@ -18,9 +18,8 @@ public class ThirdPartySender implements ThirdPartyOutputBoundary {
      * is returned so that context may be used to check the results of the action.
      *
      * @param outputModel A model containing a list of Uri, and a Context.
-     * @return ThirdPartyOutputModel A model containing a list of Uri, and a Context.
      */
-    public ThirdPartyOutputModel intentShare(ThirdPartyOutputModel outputModel){
+    public void intentShare(ThirdPartyOutputModel outputModel){
         ArrayList<Uri> fileUris = outputModel.getFileUris();
 
         Intent sendIntent = new Intent();
@@ -44,7 +43,5 @@ public class ThirdPartySender implements ThirdPartyOutputBoundary {
 
         // Create the Share Sheet.
         outputModel.getContext().startActivity(chooserIntent);
-
-        return outputModel;
     }
 }

--- a/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
@@ -23,7 +23,11 @@ public class ThirdPartySender implements ThirdPartyOutputBoundary {
      */
     public ThirdPartyOutputModel intentShare(ThirdPartyOutputModel outputModel){
         ArrayList<Uri> fileUris = outputModel.getFileUris();
+
         Intent sendIntent = new Intent();
+
+        /* FLAG_ACTIVITY_NEW_TASK needed for using context outside of an Activity class */
+        sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         sendIntent.setAction(Intent.ACTION_SEND_MULTIPLE);
         sendIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, fileUris);
 
@@ -33,7 +37,14 @@ public class ThirdPartySender implements ThirdPartyOutputBoundary {
 
         /* Send any type of text file */
         sendIntent.setType("text/*");
-        outputModel.getContext().startActivity(Intent.createChooser(sendIntent, null));
+
+        /* Made separate intent variable for creating chooser for ShareSheet, as permission need to
+        be granted using FLAG_ACTIVITY_NEW_TASK.
+         */
+        Intent chooserIntent = Intent.createChooser(sendIntent, null);
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        outputModel.getContext().startActivity(chooserIntent);
+
         return outputModel;
     }
 }

--- a/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
@@ -1,0 +1,39 @@
+package com.example.notes2text.file_sharing.adapters;
+
+import com.example.notes2text.file_sharing.use_case.ThirdPartyOutputModel;
+import com.example.notes2text.file_sharing.use_case.ThirdPartyOutputBoundary;
+
+import java.util.ArrayList;
+
+import android.net.Uri;
+import android.content.Intent;
+
+
+
+public class ThirdPartySender implements ThirdPartyOutputBoundary {
+
+
+    /**
+     * Using the list of content Uri in the given outputModel, create a new Intent
+     * to access the share sheet function. Only sends text file of any type. OutputModel
+     * is returned so that context may be used to check the results of the action.
+     *
+     * @param outputModel A model containing a list of Uri, and a Context.
+     * @return ThirdPartyOutputModel A model containing a list of Uri, and a Context.
+     */
+    public ThirdPartyOutputModel intentShare(ThirdPartyOutputModel outputModel){
+        ArrayList<Uri> fileUris = outputModel.getFileUris();
+        Intent sendIntent = new Intent();
+        sendIntent.setAction(Intent.ACTION_SEND_MULTIPLE);
+        sendIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, fileUris);
+
+        /* Grants per-use permission for other app to receive files */
+        sendIntent.addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+
+        /* Send any type of text file */
+        sendIntent.setType("text/*");
+        outputModel.getContext().startActivity(Intent.createChooser(sendIntent, null));
+        return outputModel;
+    }
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/adapters/ThirdPartySender.java
@@ -9,7 +9,6 @@ import android.net.Uri;
 import android.content.Intent;
 
 
-
 public class ThirdPartySender implements ThirdPartyOutputBoundary {
 
 
@@ -26,23 +25,24 @@ public class ThirdPartySender implements ThirdPartyOutputBoundary {
 
         Intent sendIntent = new Intent();
 
-        /* FLAG_ACTIVITY_NEW_TASK needed for using context outside of an Activity class */
+        // FLAG_ACTIVITY_NEW_TASK needed for using context outside of an Activity class.
         sendIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         sendIntent.setAction(Intent.ACTION_SEND_MULTIPLE);
         sendIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, fileUris);
 
-        /* Grants per-use permission for other app to receive files */
+        // Grants per-use permission for other app to receive files.
         sendIntent.addFlags(
                 Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
-        /* Send any type of text file */
+        // Send any type of text file.
         sendIntent.setType("text/*");
 
         /* Made separate intent variable for creating chooser for ShareSheet, as permission need to
-        be granted using FLAG_ACTIVITY_NEW_TASK.
-         */
+        be granted using FLAG_ACTIVITY_NEW_TASK. */
         Intent chooserIntent = Intent.createChooser(sendIntent, null);
         chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        // Create the Share Sheet.
         outputModel.getContext().startActivity(chooserIntent);
 
         return outputModel;

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/FileSharingModel.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/FileSharingModel.java
@@ -1,0 +1,25 @@
+package com.example.notes2text.file_sharing.use_case;
+
+import java.util.ArrayList;
+import java.io.File;
+
+import android.content.Context;
+
+
+public class FileSharingModel {
+    private final ArrayList<File> files;
+    private final Context context;
+
+    public FileSharingModel(Context context, ArrayList<File> shareFile) {
+        this.files = shareFile;
+        this.context = context;
+    }
+
+    public ArrayList<File> getFile() {
+        return files;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/MyFileProvider.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/MyFileProvider.java
@@ -4,7 +4,7 @@ import androidx.core.content.FileProvider;
 
 import com.example.notes2text.R;
 
-
+// Required implementation by Android to properly configure FileProvider.
 public class MyFileProvider extends FileProvider{
     public MyFileProvider() {
         super(R.xml.file_paths);

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/MyFileProvider.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/MyFileProvider.java
@@ -1,0 +1,12 @@
+package com.example.notes2text.file_sharing.use_case;
+
+import androidx.core.content.FileProvider;
+
+import com.example.notes2text.R;
+
+
+public class MyFileProvider extends FileProvider{
+    public MyFileProvider() {
+        super(R.xml.file_paths);
+    }
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ShareObserver.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ShareObserver.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import java.io.File;
 import java.util.ArrayList;
 
+// Used to better accommodate to Android workflow. The method has same role as main.java.
 public class ShareObserver {
 
     /**

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ShareObserver.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ShareObserver.java
@@ -1,0 +1,24 @@
+package com.example.notes2text.file_sharing.use_case;
+
+import com.example.notes2text.file_sharing.adapters.ThirdPartySender;
+
+import android.content.Context;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public class ShareObserver {
+
+    /**
+     * Called when the FileMenuInteractor wants to perform a share. This method initialize the
+     * necessary classes for sharing with Android ShareSheet, and perform the share function.
+     * @param context Context of the application, can show the current state.
+     * @param files List of IO.File that point to what the user wants to share.
+     */
+    public void share(Context context, ArrayList<File> files){
+        FileSharingModel fileToShare = new FileSharingModel(context, files);
+        ThirdPartyOutputBoundary shared = new ThirdPartySender();
+        ThirdParShareUseCase sharing = new ThirdParShareUseCase(shared);
+        sharing.share(fileToShare);
+    }
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareInputBoundary.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareInputBoundary.java
@@ -1,5 +1,0 @@
-package com.example.notes2text.file_sharing.use_case;
-
-public interface ThirdParShareInputBoundary {
-    ThirdPartyOutputModel create(FileSharingModel inputFiles);
-}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareInputBoundary.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareInputBoundary.java
@@ -1,0 +1,5 @@
+package com.example.notes2text.file_sharing.use_case;
+
+public interface ThirdParShareInputBoundary {
+    ThirdPartyOutputModel create(FileSharingModel inputFiles);
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
@@ -34,16 +34,17 @@ public class ThirdParShareUseCase {
         for (String filePath : filePaths) {
             File newFile = new File(filePath);
 
-            /* Authority can be found in AndroidManifest Provider section */
+            // Authority can be found in AndroidManifest Provider section
             Uri uri = FileProvider.getUriForFile(inputFiles.getContext(),
                     "com.example.notes2text.file_sharing.use_case.MyFileProvider", newFile);
             fileUris.add(uri);
 
             /* Since this method cannot be unit tested, Log is used to monitor output at runtime
-            with Android Logcat instead.
-             */
+            with Android Logcat instead. */
             Log.v("File conversion", String.valueOf(uri));
         }
+
+        // Make a new outputModel with the new uris and the original context to pass a layer outward.
         ThirdPartyOutputModel outputUri = new ThirdPartyOutputModel(inputFiles.getContext(),
                 fileUris);
         return outputBoundary.intentShare(outputUri);

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
@@ -1,0 +1,46 @@
+package com.example.notes2text.file_sharing.use_case;
+
+import java.util.ArrayList;
+import java.io.File;
+
+import android.net.Uri;
+import androidx.core.content.FileProvider;
+
+
+public class ThirdParShareUseCase implements ThirdParShareInputBoundary {
+    private final ThirdPartyOutputBoundary outputBoundary;
+
+    public ThirdParShareUseCase(ThirdPartyOutputBoundary outputBoundary) {
+        this.outputBoundary = outputBoundary;
+    }
+
+
+    /**
+     * Using the list of IO.File and the Context contained in the FileSharingModel to obtain
+     * a list of content Uri. Using the list of Uri and the original Context, construct
+     * and return an instance of ThirdPartyOutputModel.
+     * @param inputFiles A model containing a list of IO.File, and a Context.
+     * @return ThirdPartyOutputModel A model containing a list of Uri, and a Context.
+     */
+    @Override
+    public ThirdPartyOutputModel create(FileSharingModel inputFiles) {
+
+        ArrayList<File> files = inputFiles.getFile();
+        ArrayList<Uri> fileUris = new ArrayList<>();
+        ArrayList<String> filePaths = new ArrayList<>();
+        for (File file : files) {
+            filePaths.add(file.getAbsolutePath());
+        }
+        for (String filePath : filePaths) {
+            File newFile = new File(filePath);
+
+            /* Authority can be found in AndroidManifest Provider section */
+            Uri uri = FileProvider.getUriForFile(inputFiles.getContext(),
+                    "com.example.notes2text.file_sharing.use_case.MyFileProvider", newFile);
+            fileUris.add(uri);
+        }
+        ThirdPartyOutputModel outputUri = new ThirdPartyOutputModel(inputFiles.getContext(),
+                fileUris);
+        return outputBoundary.intentShare(outputUri);
+    }
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
@@ -7,7 +7,7 @@ import android.net.Uri;
 import androidx.core.content.FileProvider;
 
 
-public class ThirdParShareUseCase implements ThirdParShareInputBoundary {
+public class ThirdParShareUseCase {
     private final ThirdPartyOutputBoundary outputBoundary;
 
     public ThirdParShareUseCase(ThirdPartyOutputBoundary outputBoundary) {
@@ -22,8 +22,7 @@ public class ThirdParShareUseCase implements ThirdParShareInputBoundary {
      * @param inputFiles A model containing a list of IO.File, and a Context.
      * @return ThirdPartyOutputModel A model containing a list of Uri, and a Context.
      */
-    @Override
-    public ThirdPartyOutputModel create(FileSharingModel inputFiles) {
+    public ThirdPartyOutputModel share(FileSharingModel inputFiles) {
 
         ArrayList<File> files = inputFiles.getFile();
         ArrayList<Uri> fileUris = new ArrayList<>();

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
@@ -21,9 +21,8 @@ public class ThirdParShareUseCase {
      * a list of content Uri. Using the list of Uri and the original Context, construct
      * and return an instance of ThirdPartyOutputModel.
      * @param inputFiles A model containing a list of IO.File, and a Context.
-     * @return ThirdPartyOutputModel A model containing a list of Uri, and a Context.
      */
-    public ThirdPartyOutputModel share(FileSharingModel inputFiles) {
+    public void share(FileSharingModel inputFiles) {
 
         ArrayList<File> files = inputFiles.getFile();
         ArrayList<Uri> fileUris = new ArrayList<>();
@@ -47,6 +46,6 @@ public class ThirdParShareUseCase {
         // Make a new outputModel with the new uris and the original context to pass a layer outward.
         ThirdPartyOutputModel outputUri = new ThirdPartyOutputModel(inputFiles.getContext(),
                 fileUris);
-        return outputBoundary.intentShare(outputUri);
+        outputBoundary.intentShare(outputUri);
     }
 }

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdParShareUseCase.java
@@ -5,6 +5,7 @@ import java.io.File;
 
 import android.net.Uri;
 import androidx.core.content.FileProvider;
+import android.util.Log;
 
 
 public class ThirdParShareUseCase {
@@ -37,6 +38,11 @@ public class ThirdParShareUseCase {
             Uri uri = FileProvider.getUriForFile(inputFiles.getContext(),
                     "com.example.notes2text.file_sharing.use_case.MyFileProvider", newFile);
             fileUris.add(uri);
+
+            /* Since this method cannot be unit tested, Log is used to monitor output at runtime
+            with Android Logcat instead.
+             */
+            Log.v("File conversion", String.valueOf(uri));
         }
         ThirdPartyOutputModel outputUri = new ThirdPartyOutputModel(inputFiles.getContext(),
                 fileUris);

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputBoundary.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputBoundary.java
@@ -2,5 +2,5 @@ package com.example.notes2text.file_sharing.use_case;
 
 public interface ThirdPartyOutputBoundary {
 
-    ThirdPartyOutputModel intentShare(ThirdPartyOutputModel outputModel);
+    void intentShare(ThirdPartyOutputModel outputModel);
 }

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputBoundary.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputBoundary.java
@@ -1,0 +1,6 @@
+package com.example.notes2text.file_sharing.use_case;
+
+public interface ThirdPartyOutputBoundary {
+
+    ThirdPartyOutputModel intentShare(ThirdPartyOutputModel outputModel);
+}

--- a/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputModel.java
+++ b/app/src/main/java/com/example/notes2text/file_sharing/use_case/ThirdPartyOutputModel.java
@@ -1,0 +1,24 @@
+package com.example.notes2text.file_sharing.use_case;
+
+import java.util.ArrayList;
+
+import android.net.Uri;
+import android.content.Context;
+
+public class ThirdPartyOutputModel{
+    private final ArrayList<Uri> fileUris;
+    private final Context context;
+
+    public ThirdPartyOutputModel(Context context, ArrayList<Uri> shareFiles){
+        this.fileUris = shareFiles;
+        this.context = context;
+    }
+
+    public ArrayList<Uri> getFileUris(){
+        return fileUris;
+    }
+
+    public Context getContext() {
+        return context;
+    }
+}

--- a/app/src/main/java/com/example/notes2text/usecases/FileMenuInteractor.java
+++ b/app/src/main/java/com/example/notes2text/usecases/FileMenuInteractor.java
@@ -7,13 +7,18 @@ import android.widget.PopupMenu;
 import android.widget.Toast;
 
 import com.example.notes2text.adapters.DirectoryActivity;
+import com.example.notes2text.file_sharing.use_case.ShareObserver;
 
 import java.io.File;
+import java.util.ArrayList;
 
 public class FileMenuInteractor implements FileMenuInputBoundary {
 
     File keyFile;
     PopupMenu fileMenu;
+
+    /* Initialize an observer for initiating sharing function */
+    private final ShareObserver sharing = new ShareObserver();
 
     FileOpenInteractor fileOpener = new FileOpenInteractor();
     public FileMenuInteractor(PopupMenu fileMenu, File keyFile){
@@ -52,6 +57,10 @@ public class FileMenuInteractor implements FileMenuInputBoundary {
 
     @Override
     public boolean share(Context context, View view) {
+        /* Implementation of Share function */
+        ArrayList<File> files = new ArrayList<>();
+        files.add(keyFile);
+        sharing.share(context, files);
         Toast.makeText(context.getApplicationContext(), "File shared", Toast.LENGTH_SHORT).show();
         return true;
     }

--- a/app/src/main/java/com/example/notes2text/usecases/FileMenuInteractor.java
+++ b/app/src/main/java/com/example/notes2text/usecases/FileMenuInteractor.java
@@ -7,7 +7,6 @@ import android.widget.PopupMenu;
 import android.widget.Toast;
 
 import com.example.notes2text.adapters.ActivitySwitchController;
-import com.example.notes2text.adapters.DirectoryActivity;
 import com.example.notes2text.file_sharing.use_case.ShareObserver;
 
 import java.io.File;

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--Assumed storage as external Android directory-->
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
Closes #5 
Closes #13

Added classes for receiving IO.Files to convert to content type Uri, and using android sharesheet to share said files. 

All Java classes added are within the file_sharing folder. 
Include a new XML file named file_paths.xml in the res.xml folder for file path access for FileProvider.
Include changes to AndroidManifest.xml to implement FileProvider.

Not yet linked to Directory, this feature will not show when running the app. Changes should not have effects on running the app on an emulator. 