### PR TITLE
Update README.md on UNIT TESTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ The observer design pattern is used to accommodate the Android platform workflow
 
 ### Factory:
 The text editing sections of the app utilize a factory design pattern. The text editing sections work closely with the IO.File class and our own created TextFile class. The text editing sections use classes such as OpenTextEditorInteractor, SaveFile, JoinFile, EditTextInteractor, to do various tasks with the Textfile and IO.File entities. These include creating new instances of TextFile to extract the text from TextFile and to also create new instances of IO.File when saving files. 
+
+
+### Unit Testing Involving Context:
+Upon researching testing involving context, it is determined that unit testing is not viable for any classes involving context. As any Directory-related classes and method requires interaction with the Android System and thus requires the usage of Context throughout the actions. As Context is a part of the Android Environment, it cannot be accurately mocked and testing can only be done through Instrumented tests, which require running the app and will not be a unit test. 
+![image](https://github.com/CSC207-2023Y-UofT/project-notes-2-text/assets/133291994/3159dc9b-92f2-4db1-bc8c-5c72cbdc58b8) (Image taken from https://developer.android.com/training/testing/fundamentals)
+Due to this limitation, we opted to instead use Android's Log feature to record critical values used throughout these classes, and thus can monitor the action of the classes at runtime. 


### PR DESCRIPTION
closes #70 

Provided explanation on why unit testing is omitted for classes related to Directory's activities.